### PR TITLE
Unify API between single and multi hypothesis segmentations

### DIFF
--- a/src/motile_toolbox/utils/__init__.py
+++ b/src/motile_toolbox/utils/__init__.py
@@ -1,1 +1,1 @@
-from .saving_utils import relabel_segmentation
+from .relabel_segmentation import relabel_segmentation

--- a/src/motile_toolbox/utils/relabel_segmentation.py
+++ b/src/motile_toolbox/utils/relabel_segmentation.py
@@ -14,16 +14,18 @@ def relabel_segmentation(
     Args:
         solution_nx_graph (nx.DiGraph): Networkx graph with the solution to use
             for relabeling. Nodes not in graph will be removed from seg. Original
-            segmentation ids have to be stored in the graph so we can map them back.
-        segmentation (np.ndarray): Original segmentation with labels ids that correspond
-            to segmentation id in graph.
-        frame_key (str, optional): Time frame key in networkx graph. Defaults to "t".
+            segmentation ids and hypothesis ids have to be stored in the graph so we
+            can map them back.
+        segmentation (np.ndarray): Original (potentially multi-hypothesis)
+            segmentation with dimensions (t,h,[z],y,x), where h is 1 for single
+            input segmentation.
 
     Returns:
         np.ndarray: Relabeled segmentation array where nodes in same track share same
-            id.
+            id with shape (t,1,[z],y,x)
     """
-    tracked_masks = np.zeros_like(segmentation)
+    output_shape = (segmentation.shape[0], 1, *segmentation.shape[2:])
+    tracked_masks = np.zeros_like(segmentation, shape=output_shape)
     id_counter = 1
     parent_nodes = [n for (n, d) in solution_nx_graph.out_degree() if d > 1]
     soln_copy = solution_nx_graph.copy()
@@ -34,7 +36,13 @@ def relabel_segmentation(
         for node in node_set:
             time_frame = solution_nx_graph.nodes[node][NodeAttr.TIME.value]
             previous_seg_id = solution_nx_graph.nodes[node][NodeAttr.SEG_ID.value]
-            previous_seg_mask = segmentation[time_frame] == previous_seg_id
-            tracked_masks[time_frame][previous_seg_mask] = id_counter
+            if NodeAttr.SEG_HYPO.value in solution_nx_graph.nodes[node]:
+                hypothesis_id = solution_nx_graph.nodes[node][NodeAttr.SEG_HYPO.value]
+            else:
+                hypothesis_id = 0
+            previous_seg_mask = (
+                segmentation[time_frame, hypothesis_id] == previous_seg_id
+            )
+            tracked_masks[time_frame, 0][previous_seg_mask] = id_counter
         id_counter += 1
     return tracked_masks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def segmentation_2d():
     rr, cc = disk(center=(60, 45), radius=15, shape=frame_shape)
     segmentation[1][rr, cc] = 2
 
-    return segmentation
+    return np.expand_dims(segmentation, 1)
 
 
 @pytest.fixture
@@ -210,7 +210,7 @@ def segmentation_3d():
     mask = sphere(center=(60, 50, 45), radius=15, shape=frame_shape)
     segmentation[1][mask] = 2
 
-    return segmentation
+    return np.expand_dims(segmentation, 1)
 
 
 @pytest.fixture

--- a/tests/test_candidate_graph/test_compute_graph.py
+++ b/tests/test_candidate_graph/test_compute_graph.py
@@ -60,7 +60,6 @@ def test_graph_from_multi_segmentation_2d(
         segmentation=multi_hypothesis_segmentation_2d,
         max_edge_distance=100,
         iou=True,
-        multihypo=True,
     )
     assert Counter(list(cand_graph.nodes)) == Counter(
         list(multi_hypothesis_graph_2d.nodes)
@@ -87,7 +86,6 @@ def test_graph_from_multi_segmentation_2d(
     cand_graph, _ = get_candidate_graph(
         segmentation=multi_hypothesis_segmentation_2d,
         max_edge_distance=14,
-        multihypo=True,
     )
     assert Counter(list(cand_graph.nodes)) == Counter(
         list(multi_hypothesis_graph_2d.nodes)

--- a/tests/test_candidate_graph/test_iou.py
+++ b/tests/test_candidate_graph/test_iou.py
@@ -46,7 +46,7 @@ def test_multi_hypo_iou_2d(multi_hypothesis_segmentation_2d, multi_hypothesis_gr
     expected = multi_hypothesis_graph_2d
     input_graph = multi_hypothesis_graph_2d.copy()
     nx.set_edge_attributes(input_graph, -1, name=EdgeAttr.IOU.value)
-    add_iou(input_graph, multi_hypothesis_segmentation_2d, multihypo=True)
+    add_iou(input_graph, multi_hypothesis_segmentation_2d)
     for s, t, attrs in expected.edges(data=True):
         print(s, t)
         assert (

--- a/tests/test_candidate_graph/test_utils.py
+++ b/tests/test_candidate_graph/test_utils.py
@@ -17,7 +17,7 @@ from motile_toolbox.candidate_graph.utils import _compute_node_frame_dict
 def test_nodes_from_segmentation_empty():
     # test with empty segmentation
     empty_graph, node_frame_dict = nodes_from_segmentation(
-        np.zeros((3, 10, 10), dtype="int32")
+        np.zeros((3, 1, 10, 10), dtype="int32")
     )
     assert Counter(empty_graph.nodes) == Counter([])
     assert node_frame_dict == {}
@@ -37,19 +37,23 @@ def test_nodes_from_segmentation_2d(segmentation_2d):
     assert Counter(node_frame_dict[1]) == Counter(["1_1", "1_2"])
 
 
-def test_nodes_from_segmentation_2d_hypo(segmentation_2d):
+def test_nodes_from_segmentation_2d_hypo(
+    multi_hypothesis_segmentation_2d, multi_hypothesis_graph_2d
+):
     # test with 2D segmentation
     node_graph, node_frame_dict = nodes_from_segmentation(
-        segmentation=segmentation_2d, hypo_id=0
+        segmentation=multi_hypothesis_segmentation_2d
     )
-    assert Counter(list(node_graph.nodes)) == Counter(["0_0_1", "1_0_1", "1_0_2"])
+    assert Counter(list(node_graph.nodes)) == Counter(
+        list(multi_hypothesis_graph_2d.nodes)
+    )
     assert node_graph.nodes["1_0_1"][NodeAttr.SEG_ID.value] == 1
     assert node_graph.nodes["1_0_1"][NodeAttr.SEG_HYPO.value] == 0
     assert node_graph.nodes["1_0_1"][NodeAttr.TIME.value] == 1
     assert node_graph.nodes["1_0_1"][NodeAttr.POS.value] == (20, 80)
 
-    assert node_frame_dict[0] == ["0_0_1"]
-    assert Counter(node_frame_dict[1]) == Counter(["1_0_1", "1_0_2"])
+    assert Counter(node_frame_dict[0]) == Counter(["0_0_1", "0_1_1"])
+    assert Counter(node_frame_dict[1]) == Counter(["1_0_1", "1_0_2", "1_1_1", "1_1_2"])
 
 
 def test_nodes_from_segmentation_3d(segmentation_3d):

--- a/tests/test_utils/test_relabel_segmentation.py
+++ b/tests/test_utils/test_relabel_segmentation.py
@@ -5,7 +5,6 @@ from skimage.draw import disk
 
 
 def test_relabel_segmentation(segmentation_2d, graph_2d):
-    segmentation_2d = np.expand_dims(segmentation_2d, 1)
     frame_shape = (100, 100)
     expected = np.zeros(segmentation_2d.shape, dtype="int32")
     # make frame with one cell in center with label 1

--- a/tests/test_utils/test_relabel_segmentation.py
+++ b/tests/test_utils/test_relabel_segmentation.py
@@ -5,15 +5,16 @@ from skimage.draw import disk
 
 
 def test_relabel_segmentation(segmentation_2d, graph_2d):
+    segmentation_2d = np.expand_dims(segmentation_2d, 1)
     frame_shape = (100, 100)
     expected = np.zeros(segmentation_2d.shape, dtype="int32")
     # make frame with one cell in center with label 1
     rr, cc = disk(center=(50, 50), radius=20, shape=(100, 100))
-    expected[0][rr, cc] = 1
+    expected[0, 0][rr, cc] = 1
 
     # make frame with cell centered at (20, 80) with label 1
     rr, cc = disk(center=(20, 80), radius=10, shape=frame_shape)
-    expected[1][rr, cc] = 1
+    expected[1, 0][rr, cc] = 1
 
     graph_2d.remove_node("1_2")
     relabeled_seg = relabel_segmentation(graph_2d, segmentation_2d)


### PR DESCRIPTION
# Proposed Change
- Assume that segmentations always have t, h, [z], y, x
- Add ability to create final segmentation from selected graph and multihypothesis input segmentaiton
Note: This is breaking for the candidate graph creation API (need to add channel/hypothesis dim to segmentation input)

# Checklist
Go through these things before merge. Actions should run automatically to test them, but for information on how to run locally, see CONTRIBUTING.md.

- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if applicable).
- [x] I have checked that the tests pass and I maintained or improved test coverage (if applicable).
- [x] I have written docstrings and checked that they render correctly in the documentation build.
- [x] I have checked that mypy type checking passes.