### PR TITLE
Pass scale to regionprops when getting cand graph nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ ignore = [
     "D105", # Missing docstring in magic method
     "D107", # Missing docstring in `__init__
     "D205", # 1 blank line required between summary and description
+    "S101", # Use of assert detected
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/test_candidate_graph/test_utils.py
+++ b/tests/test_candidate_graph/test_utils.py
@@ -37,6 +37,18 @@ def test_nodes_from_segmentation_2d(segmentation_2d):
     assert node_frame_dict[0] == ["0_1"]
     assert Counter(node_frame_dict[1]) == Counter(["1_1", "1_2"])
 
+    # test with scaling
+    node_graph, node_frame_dict = nodes_from_segmentation(
+        segmentation=segmentation_2d, scale=[1, 1, 2]
+    )
+    assert Counter(list(node_graph.nodes)) == Counter(["0_1", "1_1", "1_2"])
+    assert node_graph.nodes["1_1"][NodeAttr.SEG_ID.value] == 1
+    assert node_graph.nodes["1_1"][NodeAttr.TIME.value] == 1
+    assert node_graph.nodes["1_1"][NodeAttr.POS.value] == (20, 160)
+
+    assert node_frame_dict[0] == ["0_1"]
+    assert Counter(node_frame_dict[1]) == Counter(["1_1", "1_2"])
+
 
 def test_nodes_from_segmentation_2d_hypo(
     multi_hypothesis_segmentation_2d, multi_hypothesis_graph_2d
@@ -66,6 +78,18 @@ def test_nodes_from_segmentation_3d(segmentation_3d):
     assert node_graph.nodes["1_1"][NodeAttr.SEG_ID.value] == 1
     assert node_graph.nodes["1_1"][NodeAttr.TIME.value] == 1
     assert node_graph.nodes["1_1"][NodeAttr.POS.value] == (20, 50, 80)
+
+    assert node_frame_dict[0] == ["0_1"]
+    assert Counter(node_frame_dict[1]) == Counter(["1_1", "1_2"])
+
+    # test with scaling
+    node_graph, node_frame_dict = nodes_from_segmentation(
+        segmentation=segmentation_3d, scale=[1, 1, 4.5, 1]
+    )
+    assert Counter(list(node_graph.nodes)) == Counter(["0_1", "1_1", "1_2"])
+    assert node_graph.nodes["1_1"][NodeAttr.SEG_ID.value] == 1
+    assert node_graph.nodes["1_1"][NodeAttr.TIME.value] == 1
+    assert node_graph.nodes["1_1"][NodeAttr.POS.value] == (20.0, 225.0, 80.0)
 
     assert node_frame_dict[0] == ["0_1"]
     assert Counter(node_frame_dict[1]) == Counter(["1_1", "1_2"])

--- a/tests/visualization/test_plot.py
+++ b/tests/visualization/test_plot.py
@@ -12,10 +12,10 @@ except ImportError:
 @pytest.fixture
 def solver(arlo_graph: motile.TrackGraph) -> motile.Solver:
     solver = motile.Solver(arlo_graph)
-    solver.add_costs(NodeSelection(weight=-1.0, attribute="score", constant=-100.0))
-    solver.add_costs(EdgeSelection(weight=1.0, attribute="prediction_distance"))
-    solver.add_costs(Appear(constant=200.0))
-    solver.add_costs(Split(constant=100.0))
+    solver.add_cost(NodeSelection(weight=-1.0, attribute="score", constant=-100.0))
+    solver.add_cost(EdgeSelection(weight=1.0, attribute="prediction_distance"))
+    solver.add_cost(Appear(constant=200.0))
+    solver.add_cost(Split(constant=100.0))
     return solver
 
 


### PR DESCRIPTION
# Proposed Change
Allow passing a scale when constructing a candidate graph. The scale is then passed to regionprops for computing region properties.

# Checklist
Go through these things before merge. Actions should run automatically to test them, but for information on how to run locally, see CONTRIBUTING.md.

- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if applicable).
- [x] I have checked that the tests pass and I maintained or improved test coverage (if applicable).
- [x] I have written docstrings and checked that they render correctly in the documentation build.
- [x] I have checked that mypy type checking passes.

# Further Comments
Scale currently includes time, and is passed a list of floats. The list of floats will change when we use funlib persistence (only ints allowed), but the inclusion of time is already future-proofed.
